### PR TITLE
Consolidate layout usage

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,5 @@
 import "/styles/globals.css";
 import "/styles/calendar.css";
-import { Box, Container } from "@mui/material";
-import Nav from "@/components/Nav";
 
 export const metadata = {
   title: "Spark-E PM App",
@@ -13,66 +11,7 @@ export const metadata = {
 
 const RootLayout = ({ children }) => (
   <html lang="en">
-    <body>
-      {/* Black Overlay */}
-      <Box
-        sx={{
-          backgroundColor: "black",
-          background: "radial-gradient(circle, rgba(2, 0, 10, 0.8) 0%, black 100%)",
-          position: "absolute",
-          content: '""',
-          zIndex: 2, // Ensures it layers above the radial gradient
-          width: "100%",
-          height: "100%",
-          top: 0,
-        }}
-        className="main"
-      >
-        {/* Background Gradient */}
-        <Box
-          sx={{
-            height: "fit-content",
-            zIndex: 3,
-            width: "100%",
-            maxWidth: "640px",
-            backgroundImage: `
-            radial-gradient(at 27% 37%, hsla(215, 98%, 61%, 1) 0px, transparent 0%),
-            radial-gradient(at 97% 21%, hsla(125, 98%, 72%, 1) 0px, transparent 50%),
-            radial-gradient(at 52% 99%, hsla(354, 98%, 61%, 1) 0px, transparent 50%),
-            radial-gradient(at 10% 29%, hsla(256, 96%, 67%, 1) 0px, transparent 50%),
-            radial-gradient(at 97% 96%, hsla(38, 60%, 74%, 1) 0px, transparent 50%),
-            radial-gradient(at 33% 50%, hsla(222, 67%, 73%, 1) 0px, transparent 50%),
-            radial-gradient(at 79% 53%, hsla(343, 68%, 79%, 1) 0px, transparent 50%)
-          `,
-            position: "absolute",
-            /*  width: "100%",
-            height: "100%", */
-            filter: "blur(100px) saturate(150%)",
-            top: "80px",
-            opacity: 0.15,
-          }}
-          className="gradient"
-        />
-      </Box>
-      {/* Main Content */}
-      <Container
-        maxWidth="lg"
-        sx={{
-          position: "relative",
-          zIndex: 10, // Ensures it layers above both gradients
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          alignItems: "center",
-          px: { xs: 2, sm: 6 }, // Responsive padding
-          mx: "auto",
-          minHeight: "100vh", // Ensures content covers the full height of the viewport
-        }}
-      >
-        <Nav />
-        <Box sx={{ flexGrow: 1, width: "100%" }}>{children}</Box>
-      </Container>
-    </body>
+    <body>{children}</body>
   </html>
 );
 

--- a/layout/Layout.tsx
+++ b/layout/Layout.tsx
@@ -2,7 +2,6 @@ import { Box, Container } from "@mui/material";
 import Head from "next/head";
 import Nav from "@/components/Nav"; // make sure this exists or replace with your nav
 import { ReactNode } from "react";
-import "/styles/globals.css";
 
 type LayoutProps = {
   title?: string;


### PR DESCRIPTION
## Summary
- strip styling from `app/layout.tsx`
- keep all layout functionality in `layout/Layout.tsx`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68597578bf1c8328af435e640d3672d1