### PR TITLE
Move markup and overhead inputs to totals

### DIFF
--- a/components/EstimateForm.tsx
+++ b/components/EstimateForm.tsx
@@ -92,8 +92,8 @@ const EstimateForm = () => {
     { name: "", units: 0, unitCost: 0, unit: "Each" },
   ]);
 
-  const [labourMarkup, setLabourMarkup] = useState(0);
-  const [materialMarkup, setMaterialMarkup] = useState(0);
+  const [markup, setMarkup] = useState(30);
+  const [overhead, setOverhead] = useState(25);
   const [esaFee, setEsaFee] = useState(0);
   const [discountType, setDiscountType] = useState("None");
   const [discountValue, setDiscountValue] = useState(0);
@@ -149,17 +149,18 @@ const EstimateForm = () => {
   );
   const labourMinMultiplier = labourHours > 0 && labourHours < 2 ? 2 / labourHours : 1;
   const labourSum = labourCost * labourMinMultiplier;
-  const labourMarkupAmt = labourSum * (labourMarkup / 100);
-  const totalLabour = labourSum + labourMarkupAmt;
+  const totalLabour = labourSum;
 
   const materialSum = materialRows.reduce(
     (sum, r) => sum + r.units * (r.unitCost / unitDivisor[r.unit]),
     0
   );
-  const materialMarkupAmt = materialSum * (materialMarkup / 100);
-  const totalMaterial = materialSum + materialMarkupAmt;
+  const totalMaterial = materialSum;
 
-  const cost = totalLabour + totalMaterial;
+  const baseCost = totalLabour + totalMaterial;
+  const markupAmt = baseCost * (markup / 100);
+  const overheadAmt = baseCost * (overhead / 100);
+  const cost = baseCost + markupAmt + overheadAmt;
   const warranty = cost * 0.03;
   const subtotal = cost + warranty + esaFee;
 
@@ -187,8 +188,8 @@ const EstimateForm = () => {
       },
       labourRows,
       materialRows,
-      labourMarkup,
-      materialMarkup,
+      markup,
+      overhead,
       esaFee,
       discountType,
       discountValue,
@@ -197,6 +198,9 @@ const EstimateForm = () => {
         materialSum,
         totalLabour,
         totalMaterial,
+        baseCost,
+        markupAmt,
+        overheadAmt,
         cost,
         warranty,
         discountAmt,
@@ -412,13 +416,6 @@ const EstimateForm = () => {
                 </IconButton>
               </Box>
               <Typography>Labour Sum: {labourSum.toFixed(2)}</Typography>
-              <TextField
-                label="Markup %"
-                type="number"
-                value={labourMarkup}
-                onChange={(e) => setLabourMarkup(Number(e.target.value))}
-              />
-              <Typography>Markup Amount: {labourMarkupAmt.toFixed(2)}</Typography>
               <Typography>Total Labour: {totalLabour.toFixed(2)}</Typography>
 
               <Typography variant="h6" fontWeight="bold" mt={4}>
@@ -497,19 +494,26 @@ const EstimateForm = () => {
                 </IconButton>
               </Box>
               <Typography>Material Sum: {materialSum.toFixed(2)}</Typography>
-              <TextField
-                label="Markup %"
-                type="number"
-                value={materialMarkup}
-                onChange={(e) => setMaterialMarkup(Number(e.target.value))}
-              />
-              <Typography>Markup Amount: {materialMarkupAmt.toFixed(2)}</Typography>
               <Typography>Total Material: {totalMaterial.toFixed(2)}</Typography>
 
               <Typography variant="h6" fontWeight="bold" mt={4}>
                 Totals
               </Typography>
-              <Typography>Cost: {cost.toFixed(2)}</Typography>
+              <Typography>Cost: {baseCost.toFixed(2)}</Typography>
+              <TextField
+                label="Markup %"
+                type="number"
+                value={markup}
+                onChange={(e) => setMarkup(Number(e.target.value))}
+              />
+              <Typography>Markup Amount: {markupAmt.toFixed(2)}</Typography>
+              <TextField
+                label="Overhead %"
+                type="number"
+                value={overhead}
+                onChange={(e) => setOverhead(Number(e.target.value))}
+              />
+              <Typography>Overhead Amount: {overheadAmt.toFixed(2)}</Typography>
               <Typography>Warranty (3%): {warranty.toFixed(2)}</Typography>
               <TextField
                 label="ESA Inspection"


### PR DESCRIPTION
## Summary
- remove markup inputs from labour and material sections
- add editable markup and overhead fields in totals section
- include markup and overhead data in the estimate form totals

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b5325cd388328b5fcb8e4c731e2dc