### PR TITLE
Fix estimate nav link

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -54,7 +54,7 @@ export default function Nav() {
 
   const pageRoutes = {
     Home: "/",
-    Estimate: "/estimate",
+    Estimate: "https://estimate.sparkeunlimited.ca",
     Journal: "/journal",
     Tasks: "/tasks",
     "Look Ahead": "/lookahead",


### PR DESCRIPTION
## Summary
- point Nav's Estimate link to `https://estimate.sparkeunlimited.ca`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865ba238eac832899a87161925bfbce