### PR TITLE
Fix journal pre-render crash

### DIFF
--- a/components/SyncStatusDashboard.tsx
+++ b/components/SyncStatusDashboard.tsx
@@ -5,7 +5,9 @@ import { Typography, Paper, Stack, Chip } from "@mui/material";
 const SyncStatusDashboard = () => {
   const [queueCount, setQueueCount] = useState(0);
   const [lastSync, setLastSync] = useState<string | null>(null);
-  const [online, setOnline] = useState(navigator.onLine);
+  const [online, setOnline] = useState(() =>
+    typeof navigator !== "undefined" ? navigator.onLine : false
+  );
 
   useEffect(() => {
     const update = async () => {


### PR DESCRIPTION
## Summary
- guard against server-side `navigator` access in the sync dashboard

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68694254fbf88328bd9374dc2144564b