### PR TITLE
Add EHS forms

### DIFF
--- a/app/components/forms/CorrectiveActionRegisterForm.tsx
+++ b/app/components/forms/CorrectiveActionRegisterForm.tsx
@@ -1,0 +1,9 @@
+"use client";
+import formDefinition from "@/lib/EHS/Corrective_Action_Register.json";
+import FormRenderer from "./FormRenderer";
+
+const CorrectiveActionRegisterForm = () => (
+  <FormRenderer definition={formDefinition} />
+);
+
+export default CorrectiveActionRegisterForm;

--- a/app/components/forms/FormRenderer.tsx
+++ b/app/components/forms/FormRenderer.tsx
@@ -1,0 +1,161 @@
+"use client";
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  FormGroup,
+  Stack,
+  MenuItem,
+  Paper,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { submitEHSForm } from "@/lib/api";
+
+export type FormField = {
+  label: string;
+  type: string;
+  options?: string[];
+};
+export type FormSection = {
+  title: string;
+  fields: FormField[];
+};
+export type FormDefinition = {
+  title: string;
+  description: string;
+  sections: FormSection[];
+};
+
+const FormRenderer = ({ definition }: { definition: FormDefinition }) => {
+  const [data, setData] = useState<Record<string, any>>({});
+
+  const handleChange = (key: string, value: any) => {
+    setData((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await submitEHSForm(definition.title, data);
+  };
+
+  const renderField = (field: FormField, key: string) => {
+    const value = data[key] ?? (field.type === "checkbox" && field.options ? [] : field.type === "checkbox" ? false : "");
+    switch (field.type) {
+      case "text":
+        return (
+          <TextField label={field.label} fullWidth value={value} onChange={(e) => handleChange(key, e.target.value)} />
+        );
+      case "textarea":
+        return (
+          <TextField
+            label={field.label}
+            fullWidth
+            multiline
+            rows={4}
+            value={value}
+            onChange={(e) => handleChange(key, e.target.value)}
+          />
+        );
+      case "date":
+        return (
+          <TextField
+            label={field.label}
+            type="date"
+            InputLabelProps={{ shrink: true }}
+            fullWidth
+            value={value}
+            onChange={(e) => handleChange(key, e.target.value)}
+          />
+        );
+      case "dropdown":
+        return (
+          <TextField
+            select
+            label={field.label}
+            fullWidth
+            value={value}
+            onChange={(e) => handleChange(key, e.target.value)}
+          >
+            {field.options?.map((opt) => (
+              <MenuItem key={opt} value={opt}>
+                {opt}
+              </MenuItem>
+            ))}
+          </TextField>
+        );
+      case "checkbox":
+        if (field.options) {
+          const arr: string[] = Array.isArray(value) ? value : [];
+          return (
+            <FormGroup>
+              <Typography>{field.label}</Typography>
+              {field.options.map((opt) => (
+                <FormControlLabel
+                  key={opt}
+                  control={
+                    <Checkbox
+                      checked={arr.includes(opt)}
+                      onChange={(e) => {
+                        const newArr = e.target.checked
+                          ? [...arr, opt]
+                          : arr.filter((o) => o !== opt);
+                        handleChange(key, newArr);
+                      }}
+                    />
+                  }
+                  label={opt}
+                />
+              ))}
+            </FormGroup>
+          );
+        }
+        return (
+          <FormControlLabel
+            control={<Checkbox checked={!!value} onChange={(e) => handleChange(key, e.target.checked)} />}
+            label={field.label}
+          />
+        );
+      case "signature":
+        return (
+          <TextField
+            label={field.label}
+            fullWidth
+            value={value}
+            onChange={(e) => handleChange(key, e.target.value)}
+            placeholder="Signature"
+          />
+        );
+      default:
+        return (
+          <TextField label={field.label} fullWidth value={value} onChange={(e) => handleChange(key, e.target.value)} />
+        );
+    }
+  };
+
+  return (
+    <Paper sx={{ p: 4 }} elevation={4}>
+      <Box component="form" onSubmit={handleSubmit}>
+        {definition.sections.map((section, si) => (
+          <Box key={si} sx={{ mb: 3 }}>
+            <Typography variant="h6" gutterBottom>
+              {section.title}
+            </Typography>
+            <Stack spacing={2}>
+              {section.fields.map((field, fi) => (
+                <Box key={fi}>{renderField(field, `${si}-${fi}`)}</Box>
+              ))}
+            </Stack>
+          </Box>
+        ))}
+        <Button variant="contained" type="submit">
+          Submit
+        </Button>
+      </Box>
+    </Paper>
+  );
+};
+
+export default FormRenderer;

--- a/app/components/forms/InternalAuditChecklistForm.tsx
+++ b/app/components/forms/InternalAuditChecklistForm.tsx
@@ -1,0 +1,9 @@
+"use client";
+import formDefinition from "@/lib/EHS/Internal_Audit_Checklist.json";
+import FormRenderer from "./FormRenderer";
+
+const InternalAuditChecklistForm = () => (
+  <FormRenderer definition={formDefinition} />
+);
+
+export default InternalAuditChecklistForm;

--- a/app/components/forms/InternalAuditReportForm.tsx
+++ b/app/components/forms/InternalAuditReportForm.tsx
@@ -1,0 +1,9 @@
+"use client";
+import formDefinition from "@/lib/EHS/Internal_Audit_Report.json";
+import FormRenderer from "./FormRenderer";
+
+const InternalAuditReportForm = () => (
+  <FormRenderer definition={formDefinition} />
+);
+
+export default InternalAuditReportForm;

--- a/app/components/forms/ModifiedDutyLogForm.tsx
+++ b/app/components/forms/ModifiedDutyLogForm.tsx
@@ -1,0 +1,9 @@
+"use client";
+import formDefinition from "@/lib/EHS/Modified_Duty_Log.json";
+import FormRenderer from "./FormRenderer";
+
+const ModifiedDutyLogForm = () => (
+  <FormRenderer definition={formDefinition} />
+);
+
+export default ModifiedDutyLogForm;

--- a/app/components/forms/ReturnToWorkAgreementForm.tsx
+++ b/app/components/forms/ReturnToWorkAgreementForm.tsx
@@ -1,0 +1,9 @@
+"use client";
+import formDefinition from "@/lib/EHS/Return_to_Work_Agreement.json";
+import FormRenderer from "./FormRenderer";
+
+const ReturnToWorkAgreementForm = () => (
+  <FormRenderer definition={formDefinition} />
+);
+
+export default ReturnToWorkAgreementForm;

--- a/app/components/forms/SafetyObjectiveWorksheetForm.tsx
+++ b/app/components/forms/SafetyObjectiveWorksheetForm.tsx
@@ -1,0 +1,20 @@
+"use client";
+import raw from "@/lib/EHS/Safety_Objective_Worksheet.json";
+import FormRenderer, { FormDefinition } from "./FormRenderer";
+
+const definition: FormDefinition = {
+  title: raw.title,
+  description: raw.description,
+  sections: [
+    {
+      title: "Objectives",
+      fields: raw.columns.map((c: string) => ({ label: c, type: "text" })),
+    },
+  ],
+};
+
+const SafetyObjectiveWorksheetForm = () => (
+  <FormRenderer definition={definition} />
+);
+
+export default SafetyObjectiveWorksheetForm;

--- a/app/ehs/page.tsx
+++ b/app/ehs/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+import Layout from "@/layout/Layout";
+import { List, ListItem, ListItemText, Typography } from "@mui/material";
+import Link from "next/link";
+import CorrectiveActionRegister from "@/lib/EHS/Corrective_Action_Register.json";
+import InternalAuditChecklist from "@/lib/EHS/Internal_Audit_Checklist.json";
+import InternalAuditReport from "@/lib/EHS/Internal_Audit_Report.json";
+import ModifiedDutyLog from "@/lib/EHS/Modified_Duty_Log.json";
+import ReturnToWorkAgreement from "@/lib/EHS/Return_to_Work_Agreement.json";
+import SafetyObjectiveWorksheet from "@/lib/EHS/Safety_Objective_Worksheet.json";
+
+const forms = [
+  { def: CorrectiveActionRegister, slug: "corrective-action-register" },
+  { def: InternalAuditChecklist, slug: "internal-audit-checklist" },
+  { def: InternalAuditReport, slug: "internal-audit-report" },
+  { def: ModifiedDutyLog, slug: "modified-duty-log" },
+  { def: ReturnToWorkAgreement, slug: "return-to-work-agreement" },
+  { def: SafetyObjectiveWorksheet, slug: "safety-objective-worksheet" },
+];
+
+export default function EHSPage() {
+  return (
+    <Layout title="Employee Health and Safety">
+      <Typography variant="h4" gutterBottom>
+        Employee Health and Safety
+      </Typography>
+      <Typography paragraph>
+        Below are the available EHS forms. Select one to begin.
+      </Typography>
+      <List>
+        {forms.map((f) => (
+          <ListItem key={f.slug} component={Link} href={`/forms/${f.slug}`}> 
+            <ListItemText primary={f.def.title} />
+          </ListItem>
+        ))}
+      </List>
+    </Layout>
+  );
+}

--- a/app/forms/corrective-action-register/page.tsx
+++ b/app/forms/corrective-action-register/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+import Layout from "@/layout/Layout";
+import formDefinition from "@/lib/EHS/Corrective_Action_Register.json";
+import CorrectiveActionRegisterForm from "@/app/components/forms/CorrectiveActionRegisterForm";
+import { Typography } from "@mui/material";
+
+export default function Page() {
+  return (
+    <Layout title={formDefinition.title}>
+      <Typography variant="h4" gutterBottom>
+        {formDefinition.title}
+      </Typography>
+      <Typography paragraph>{formDefinition.description}</Typography>
+      <CorrectiveActionRegisterForm />
+    </Layout>
+  );
+}

--- a/app/forms/internal-audit-checklist/page.tsx
+++ b/app/forms/internal-audit-checklist/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+import Layout from "@/layout/Layout";
+import formDefinition from "@/lib/EHS/Internal_Audit_Checklist.json";
+import InternalAuditChecklistForm from "@/app/components/forms/InternalAuditChecklistForm";
+import { Typography } from "@mui/material";
+
+export default function Page() {
+  return (
+    <Layout title={formDefinition.title}>
+      <Typography variant="h4" gutterBottom>
+        {formDefinition.title}
+      </Typography>
+      <Typography paragraph>{formDefinition.description}</Typography>
+      <InternalAuditChecklistForm />
+    </Layout>
+  );
+}

--- a/app/forms/internal-audit-report/page.tsx
+++ b/app/forms/internal-audit-report/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+import Layout from "@/layout/Layout";
+import formDefinition from "@/lib/EHS/Internal_Audit_Report.json";
+import InternalAuditReportForm from "@/app/components/forms/InternalAuditReportForm";
+import { Typography } from "@mui/material";
+
+export default function Page() {
+  return (
+    <Layout title={formDefinition.title}>
+      <Typography variant="h4" gutterBottom>
+        {formDefinition.title}
+      </Typography>
+      <Typography paragraph>{formDefinition.description}</Typography>
+      <InternalAuditReportForm />
+    </Layout>
+  );
+}

--- a/app/forms/modified-duty-log/page.tsx
+++ b/app/forms/modified-duty-log/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+import Layout from "@/layout/Layout";
+import formDefinition from "@/lib/EHS/Modified_Duty_Log.json";
+import ModifiedDutyLogForm from "@/app/components/forms/ModifiedDutyLogForm";
+import { Typography } from "@mui/material";
+
+export default function Page() {
+  return (
+    <Layout title={formDefinition.title}>
+      <Typography variant="h4" gutterBottom>
+        {formDefinition.title}
+      </Typography>
+      <Typography paragraph>{formDefinition.description}</Typography>
+      <ModifiedDutyLogForm />
+    </Layout>
+  );
+}

--- a/app/forms/return-to-work-agreement/page.tsx
+++ b/app/forms/return-to-work-agreement/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+import Layout from "@/layout/Layout";
+import formDefinition from "@/lib/EHS/Return_to_Work_Agreement.json";
+import ReturnToWorkAgreementForm from "@/app/components/forms/ReturnToWorkAgreementForm";
+import { Typography } from "@mui/material";
+
+export default function Page() {
+  return (
+    <Layout title={formDefinition.title}>
+      <Typography variant="h4" gutterBottom>
+        {formDefinition.title}
+      </Typography>
+      <Typography paragraph>{formDefinition.description}</Typography>
+      <ReturnToWorkAgreementForm />
+    </Layout>
+  );
+}

--- a/app/forms/safety-objective-worksheet/page.tsx
+++ b/app/forms/safety-objective-worksheet/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+import Layout from "@/layout/Layout";
+import formDefinition from "@/lib/EHS/Safety_Objective_Worksheet.json";
+import SafetyObjectiveWorksheetForm from "@/app/components/forms/SafetyObjectiveWorksheetForm";
+import { Typography } from "@mui/material";
+
+export default function Page() {
+  return (
+    <Layout title={formDefinition.title}>
+      <Typography variant="h4" gutterBottom>
+        {formDefinition.title}
+      </Typography>
+      <Typography paragraph>{formDefinition.description}</Typography>
+      <SafetyObjectiveWorksheetForm />
+    </Layout>
+  );
+}

--- a/app/safety/page.tsx
+++ b/app/safety/page.tsx
@@ -2,10 +2,12 @@
 import Layout from "@/layout/Layout";
 import DailySafetyReview from "@/components/DailySafetyReview";
 import EquipmentSafetyCheck from "@/components/EquipmentSafetyCheck";
+import EHSIntro from "@/components/EHSIntro";
 
 export default function SafetyPage() {
   return (
     <Layout title="Site Safety">
+      <EHSIntro />
       <DailySafetyReview />
       <EquipmentSafetyCheck />
     </Layout>

--- a/components/EHSIntro.tsx
+++ b/components/EHSIntro.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { Paper, Typography } from "@mui/material";
+
+const EHSIntro = () => (
+  <Paper sx={{ p: 4, mb: 3 }} elevation={4}>
+    <Typography variant="h5" gutterBottom>
+      Employee Health and Safety (EHS)
+    </Typography>
+    <Typography variant="body1">
+      This section provides resources and forms related to our Employee Health and
+      Safety program. Select a form from the navigation to get started.
+    </Typography>
+  </Paper>
+);
+
+export default EHSIntro;

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -23,9 +23,16 @@ import { useRouter } from "next/navigation";
 import WorkIcon from "@mui/icons-material/Work";
 import AssignmentIcon from "@mui/icons-material/Assignment";
 import SafetyCheckIcon from "@mui/icons-material/HealthAndSafety";
+import DescriptionIcon from "@mui/icons-material/Description";
 import BuildIcon from "@mui/icons-material/Build";
 import DashboardIcon from "@mui/icons-material/Dashboard";
 import NotesIcon from "@mui/icons-material/StickyNote2";
+import CorrectiveActionRegister from "@/lib/EHS/Corrective_Action_Register.json";
+import InternalAuditChecklist from "@/lib/EHS/Internal_Audit_Checklist.json";
+import InternalAuditReport from "@/lib/EHS/Internal_Audit_Report.json";
+import ModifiedDutyLog from "@/lib/EHS/Modified_Duty_Log.json";
+import ReturnToWorkAgreement from "@/lib/EHS/Return_to_Work_Agreement.json";
+import SafetyObjectiveWorksheet from "@/lib/EHS/Safety_Objective_Worksheet.json";
 
 const basePages = [
   "Estimate",
@@ -33,6 +40,7 @@ const basePages = [
   "Tasks",
   "Look Ahead",
   "Safety",
+  "EHS",
   "Tools",
   "Dashboard",
 ] as const;
@@ -43,9 +51,19 @@ const pageIcons = {
   Tasks: <AssignmentIcon fontSize="large" />,
   "Look Ahead": <WorkIcon fontSize="large" />,
   Safety: <SafetyCheckIcon fontSize="large" />,
+  EHS: <SafetyCheckIcon fontSize="large" />,
   Tools: <BuildIcon fontSize="large" />,
   Dashboard: <DashboardIcon fontSize="large" />,
 };
+
+const formLinks = [
+  { title: CorrectiveActionRegister.title, slug: "corrective-action-register" },
+  { title: InternalAuditChecklist.title, slug: "internal-audit-checklist" },
+  { title: InternalAuditReport.title, slug: "internal-audit-report" },
+  { title: ModifiedDutyLog.title, slug: "modified-duty-log" },
+  { title: ReturnToWorkAgreement.title, slug: "return-to-work-agreement" },
+  { title: SafetyObjectiveWorksheet.title, slug: "safety-objective-worksheet" },
+];
 
 export default function Nav() {
   const router = useRouter();
@@ -59,18 +77,28 @@ export default function Nav() {
     Tasks: "/tasks",
     "Look Ahead": "/lookahead",
     Safety: "/safety",
+    EHS: "/ehs",
     Tools: "/tools",
     Dashboard: "/dashboard",
   };
 
   const [anchorElNav, setAnchorElNav] = React.useState(null);
+  const [anchorElForms, setAnchorElForms] = React.useState<null | HTMLElement>(null);
 
   const handleOpenNavMenu = (event) => {
     setAnchorElNav(event.currentTarget);
   };
 
+  const handleOpenFormsMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorElForms(event.currentTarget);
+  };
+
   const handleCloseNavMenu = () => {
     setAnchorElNav(null);
+  };
+
+  const handleCloseFormsMenu = () => {
+    setAnchorElForms(null);
   };
 
   return (
@@ -141,6 +169,18 @@ export default function Nav() {
                   <Typography sx={{ textAlign: "center", marginLeft: 1 }}>{page}</Typography>
                 </MenuItem>
               ))}
+              {formLinks.map((form) => (
+                <MenuItem
+                  key={form.slug}
+                  onClick={() => {
+                    handleCloseNavMenu();
+                    router.push(`/forms/${form.slug}`);
+                  }}
+                >
+                  <DescriptionIcon sx={{ mr: 1 }} />
+                  <Typography>{form.title}</Typography>
+                </MenuItem>
+              ))}
             </Menu>
           </Box>
 
@@ -187,6 +227,30 @@ export default function Nav() {
                 {page}
               </Button>
             ))}
+            <Button
+              onClick={handleOpenFormsMenu}
+              sx={{ my: 3, color: "white", fontWeight: 800 }}
+              startIcon={<DescriptionIcon />}
+            >
+              Forms
+            </Button>
+            <Menu
+              anchorEl={anchorElForms}
+              open={Boolean(anchorElForms)}
+              onClose={handleCloseFormsMenu}
+            >
+              {formLinks.map((form) => (
+                <MenuItem
+                  key={form.slug}
+                  onClick={() => {
+                    handleCloseFormsMenu();
+                    router.push(`/forms/${form.slug}`);
+                  }}
+                >
+                  {form.title}
+                </MenuItem>
+              ))}
+            </Menu>
           </Box>
         </Toolbar>
       </Container>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -9,3 +9,8 @@ export const sendEstimateEmail = async (data: any, pdf: Blob) => {
 export const ensureCustomerFolder = async (path: string) => {
   console.log("Ensuring folder exists:", path);
 };
+
+export const submitEHSForm = async (title: string, data: any) => {
+  console.log(`Submitting ${title} form to DynamoDB`, data);
+  // Placeholder for API call
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- add an intro component on the Safety page
- generate form components from JSON definitions
- add pages for each form under `/forms`
- create an Employee Health and Safety landing page
- extend Nav with EHS links and dropdown for all forms
- add stubbed API helper for submitting EHS forms

## Testing
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687403865b74832889f4fdfe52947469