### PR TITLE
Add dynamic form renderer

### DIFF
--- a/app/api/forms/submit/route.ts
+++ b/app/api/forms/submit/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { DynamoDBClient, PutItemCommand } from "@aws-sdk/client-dynamodb";
+
+const client = new DynamoDBClient({ region: "us-east-1" });
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+
+  const item = {
+    PK: { S: `FORM#${body.formTitle}` },
+    SK: { S: `SUBMIT#${body.submissionDate}` },
+    Data: { S: JSON.stringify(body.sections) },
+  };
+
+  const command = new PutItemCommand({
+    TableName: "EHSForms",
+    Item: item,
+  });
+
+  try {
+    await client.send(command);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to write to DynamoDB" }, {
+      status: 500,
+    });
+  }
+}

--- a/app/forms/internal-audit-checklist/page.tsx
+++ b/app/forms/internal-audit-checklist/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+import Layout from "@/layout/Layout";
+import FormRenderer from "@/components/FormRenderer";
+import formJson from "@/lib/EHS/Internal_Audit_Checklist.json";
+
+export default function InternalAuditChecklistPage() {
+  return (
+    <Layout title="Internal Audit Checklist">
+      <FormRenderer formJson={formJson} />
+    </Layout>
+  );
+}

--- a/components/FormRenderer.tsx
+++ b/components/FormRenderer.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  IconButton,
+  MenuItem,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+
+export type FormField = {
+  label: string;
+  type: string;
+  options?: string[];
+};
+
+export type FormSection = {
+  title: string;
+  fields: FormField[];
+};
+
+export type FormJson = {
+  title: string;
+  sections: FormSection[];
+};
+
+// Row data for each section table
+type RowData = {
+  fieldKey: string;
+  value?: any;
+  notes?: string;
+};
+
+const renderFieldControl = (
+  field: FormField,
+  row: RowData,
+  update: (val: Partial<RowData>) => void,
+) => {
+  switch (field.type) {
+    case "checkbox":
+      return (
+        <FormGroup>
+          {field.options?.map((opt) => (
+            <FormControlLabel
+              key={opt}
+              control={
+                <Checkbox
+                  checked={Array.isArray(row.value) ? row.value.includes(opt) : false}
+                  onChange={(e) => {
+                    const arr = Array.isArray(row.value) ? [...row.value] : [];
+                    if (e.target.checked) arr.push(opt);
+                    else
+                      update({ value: arr.filter((v) => v !== opt) });
+                    update({ value: arr });
+                  }}
+                />
+              }
+              label={opt}
+            />
+          ))}
+        </FormGroup>
+      );
+    case "dropdown":
+      return (
+        <FormControl fullWidth size="small">
+          <Select
+            value={row.value || ""}
+            onChange={(e) => update({ value: e.target.value })}
+          >
+            {field.options?.map((opt) => (
+              <MenuItem key={opt} value={opt}>
+                {opt}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      );
+    case "textarea":
+      return (
+        <TextField
+          multiline
+          minRows={3}
+          value={row.value || ""}
+          onChange={(e) => update({ value: e.target.value })}
+          fullWidth
+        />
+      );
+    case "date":
+      return (
+        <TextField
+          type="date"
+          value={row.value || ""}
+          onChange={(e) => update({ value: e.target.value })}
+          fullWidth
+        />
+      );
+    case "text":
+    default:
+      return (
+        <TextField
+          value={row.value || ""}
+          onChange={(e) => update({ value: e.target.value })}
+          fullWidth
+        />
+      );
+  }
+};
+
+const FormRenderer = ({ formJson }: { formJson: FormJson }) => {
+  const [sectionRows, setSectionRows] = useState<Record<string, RowData[]>>({});
+
+  useEffect(() => {
+    const init: Record<string, RowData[]> = {};
+    formJson.sections.forEach((s) => {
+      init[s.title] = [{ fieldKey: "" }];
+    });
+    setSectionRows(init);
+  }, [formJson]);
+
+  const updateRow = (
+    section: string,
+    idx: number,
+    row: Partial<RowData>,
+  ) => {
+    setSectionRows((prev) => {
+      const rows = prev[section] ? [...prev[section]] : [];
+      rows[idx] = { ...rows[idx], ...row };
+      return { ...prev, [section]: rows };
+    });
+  };
+
+  const handleSelectField = (
+    section: string,
+    idx: number,
+    fieldKey: string,
+  ) => {
+    setSectionRows((prev) => {
+      const rows = prev[section] ? [...prev[section]] : [];
+      rows[idx] = { fieldKey };
+      // append new row if last and not empty
+      if (idx === rows.length - 1 && fieldKey) {
+        rows.push({ fieldKey: "" });
+      }
+      return { ...prev, [section]: rows };
+    });
+  };
+
+  const removeRow = (section: string, idx: number) => {
+    setSectionRows((prev) => {
+      const rows = prev[section] ? [...prev[section]] : [];
+      rows.splice(idx, 1);
+      if (rows.length === 0) rows.push({ fieldKey: "" });
+      return { ...prev, [section]: rows };
+    });
+  };
+
+  const handleSubmit = async () => {
+    const response = await fetch("/api/forms/submit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        formTitle: formJson.title,
+        submissionDate: new Date().toISOString(),
+        sections: sectionRows,
+      }),
+    });
+
+    if (response.ok) {
+      alert("Submission successful");
+    } else {
+      alert("Failed to submit");
+    }
+  };
+
+  return (
+    <Box>
+      {formJson.sections.map((section) => (
+        <Box key={section.title} mb={4}>
+          <Typography variant="h6" fontWeight="bold" gutterBottom>
+            {section.title}
+          </Typography>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Field</TableCell>
+                <TableCell>Value</TableCell>
+                <TableCell />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {sectionRows[section.title]?.map((row, idx) => {
+                const field = section.fields.find((f) => f.label === row.fieldKey);
+                return (
+                  <>
+                    <TableRow key={`${section.title}-${idx}`}>
+                      <TableCell sx={{ width: "30%" }}>
+                        <Select
+                          size="small"
+                          fullWidth
+                          value={row.fieldKey}
+                          onChange={(e) =>
+                            handleSelectField(
+                              section.title,
+                              idx,
+                              e.target.value as string,
+                            )
+                          }
+                        >
+                          <MenuItem value="">Select field</MenuItem>
+                          {section.fields.map((f) => (
+                            <MenuItem key={f.label} value={f.label}>
+                              {f.label}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </TableCell>
+                      <TableCell>
+                        {field &&
+                          renderFieldControl(field, row, (val) =>
+                            updateRow(section.title, idx, val),
+                          )}
+                      </TableCell>
+                      <TableCell>
+                        <IconButton onClick={() => removeRow(section.title, idx)}>
+                          <DeleteIcon />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                    {field &&
+                      (field.type === "checkbox" || field.type === "dropdown") && (
+                        <TableRow key={`${section.title}-${idx}-notes`}>
+                          <TableCell colSpan={3}>
+                            <TextField
+                              fullWidth
+                              label="Notes"
+                              value={row.notes || ""}
+                              onChange={(e) =>
+                                updateRow(section.title, idx, {
+                                  notes: e.target.value,
+                                })
+                              }
+                            />
+                          </TableCell>
+                        </TableRow>
+                      )}
+                  </>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </Box>
+      ))}
+      <Button onClick={handleSubmit} variant="contained" color="primary">
+        Submit Form
+      </Button>
+    </Box>
+  );
+};
+
+export default FormRenderer;


### PR DESCRIPTION
## Summary
- implement dynamic `FormRenderer` component for EHS forms
- add API route `app/api/forms/submit` to store form submissions in DynamoDB
- expose example page for Internal Audit Checklist using new renderer

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@aws-sdk/client-dynamodb')*

------
https://chatgpt.com/codex/tasks/task_e_68751ad7e020832894908e8b9149e054