### PR TITLE
Merge dynamic table form renderer

### DIFF
--- a/app/forms/internal-audit-checklist/page.tsx
+++ b/app/forms/internal-audit-checklist/page.tsx
@@ -1,12 +1,7 @@
 "use client";
-import Layout from "@/layout/Layout";
-import FormRenderer from "@/components/FormRenderer";
+import FormRenderer from "@/components/Forms/FormRenderer";
 import formJson from "@/lib/EHS/Internal_Audit_Checklist.json";
 
 export default function InternalAuditChecklistPage() {
-  return (
-    <Layout title="Internal Audit Checklist">
-      <FormRenderer formJson={formJson} />
-    </Layout>
-  );
+  return <FormRenderer definition={formJson} />;
 }

--- a/components/Forms/FormRenderer.tsx
+++ b/components/Forms/FormRenderer.tsx
@@ -1,18 +1,25 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Box,
   Button,
   Checkbox,
+  FormControl,
   FormControlLabel,
   FormGroup,
-  Stack,
+  IconButton,
   MenuItem,
   Paper,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
   TextField,
   Typography,
 } from "@mui/material";
-import { submitEHSForm } from "@/lib/api";
+import DeleteIcon from "@mui/icons-material/Delete";
 import Layout from "@/layout/Layout";
 
 export type FormField = {
@@ -30,147 +37,215 @@ export type FormDefinition = {
   sections: FormSection[];
 };
 
-const FormRenderer = ({ definition }: { definition: FormDefinition }) => {
-  const [data, setData] = useState<Record<string, any>>({});
+type RowData = {
+  fieldKey: string;
+  value?: any;
+  notes?: string;
+};
 
-  const handleChange = (key: string, value: any) => {
-    setData((prev) => ({ ...prev, [key]: value }));
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    await submitEHSForm( data);
-  };
-
-  const renderField = (field: FormField, key: string) => {
-    const value =
-      data[key] ??
-      (field.type === "checkbox" && field.options ? [] : field.type === "checkbox" ? false : "");
-    switch (field.type) {
-      case "text":
-        return (
-          <TextField
-            label={field.label}
-            fullWidth
-            value={value}
-            onChange={(e) => handleChange(key, e.target.value)}
-          />
-        );
-      case "textarea":
-        return (
-          <TextField
-            label={field.label}
-            fullWidth
-            multiline
-            rows={4}
-            value={value}
-            onChange={(e) => handleChange(key, e.target.value)}
-          />
-        );
-      case "date":
-        return (
-          <TextField
-            label={field.label}
-            type="date"
-            InputLabelProps={{ shrink: true }}
-            fullWidth
-            value={value}
-            onChange={(e) => handleChange(key, e.target.value)}
-          />
-        );
-      case "dropdown":
-        return (
-          <TextField
-            select
-            label={field.label}
-            fullWidth
-            value={value}
-            onChange={(e) => handleChange(key, e.target.value)}
-          >
+const renderFieldControl = (
+  field: FormField,
+  row: RowData,
+  update: (val: Partial<RowData>) => void,
+) => {
+  switch (field.type) {
+    case "checkbox":
+      return (
+        <FormGroup>
+          {field.options?.map((opt) => (
+            <FormControlLabel
+              key={opt}
+              control={
+                <Checkbox
+                  checked={Array.isArray(row.value) ? row.value.includes(opt) : false}
+                  onChange={(e) => {
+                    const arr = Array.isArray(row.value) ? [...row.value] : [];
+                    if (e.target.checked) arr.push(opt);
+                    else update({ value: arr.filter((v) => v !== opt) });
+                    update({ value: arr });
+                  }}
+                />
+              }
+              label={opt}
+            />
+          ))}
+        </FormGroup>
+      );
+    case "dropdown":
+      return (
+        <FormControl fullWidth size="small">
+          <Select value={row.value || ""} onChange={(e) => update({ value: e.target.value })}>
             {field.options?.map((opt) => (
               <MenuItem key={opt} value={opt}>
                 {opt}
               </MenuItem>
             ))}
-          </TextField>
-        );
-      case "checkbox":
-        if (field.options) {
-          const arr: string[] = Array.isArray(value) ? value : [];
-          return (
-            <FormGroup>
-              <Typography>{field.label}</Typography>
-              {field.options.map((opt) => (
-                <FormControlLabel
-                  key={opt}
-                  control={
-                    <Checkbox
-                      checked={arr.includes(opt)}
-                      onChange={(e) => {
-                        const newArr = e.target.checked
-                          ? [...arr, opt]
-                          : arr.filter((o) => o !== opt);
-                        handleChange(key, newArr);
-                      }}
-                    />
-                  }
-                  label={opt}
-                />
-              ))}
-            </FormGroup>
-          );
-        }
-        return (
-          <FormControlLabel
-            control={
-              <Checkbox checked={!!value} onChange={(e) => handleChange(key, e.target.checked)} />
-            }
-            label={field.label}
-          />
-        );
-      case "signature":
-        return (
-          <TextField
-            label={field.label}
-            fullWidth
-            value={value}
-            onChange={(e) => handleChange(key, e.target.value)}
-            placeholder="Signature"
-          />
-        );
-      default:
-        return (
-          <TextField
-            label={field.label}
-            fullWidth
-            value={value}
-            onChange={(e) => handleChange(key, e.target.value)}
-          />
-        );
+          </Select>
+        </FormControl>
+      );
+    case "textarea":
+      return (
+        <TextField
+          multiline
+          minRows={3}
+          value={row.value || ""}
+          onChange={(e) => update({ value: e.target.value })}
+          fullWidth
+        />
+      );
+    case "date":
+      return (
+        <TextField
+          type="date"
+          value={row.value || ""}
+          onChange={(e) => update({ value: e.target.value })}
+          fullWidth
+        />
+      );
+    case "text":
+    default:
+      return (
+        <TextField value={row.value || ""} onChange={(e) => update({ value: e.target.value })} fullWidth />
+      );
+  }
+};
+
+const FormRenderer = ({ definition }: { definition: FormDefinition }) => {
+  const [sectionRows, setSectionRows] = useState<Record<string, RowData[]>>({});
+
+  useEffect(() => {
+    const init: Record<string, RowData[]> = {};
+    definition.sections.forEach((s) => {
+      init[s.title] = [{ fieldKey: "" }];
+    });
+    setSectionRows(init);
+  }, [definition]);
+
+  const updateRow = (section: string, idx: number, row: Partial<RowData>) => {
+    setSectionRows((prev) => {
+      const rows = prev[section] ? [...prev[section]] : [];
+      rows[idx] = { ...rows[idx], ...row };
+      return { ...prev, [section]: rows };
+    });
+  };
+
+  const handleSelectField = (section: string, idx: number, fieldKey: string) => {
+    setSectionRows((prev) => {
+      const rows = prev[section] ? [...prev[section]] : [];
+      rows[idx] = { fieldKey };
+      if (idx === rows.length - 1 && fieldKey) {
+        rows.push({ fieldKey: "" });
+      }
+      return { ...prev, [section]: rows };
+    });
+  };
+
+  const removeRow = (section: string, idx: number) => {
+    setSectionRows((prev) => {
+      const rows = prev[section] ? [...prev[section]] : [];
+      rows.splice(idx, 1);
+      if (rows.length === 0) rows.push({ fieldKey: "" });
+      return { ...prev, [section]: rows };
+    });
+  };
+
+  const handleSubmit = async () => {
+    const response = await fetch("/api/forms/submit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        formTitle: definition.title,
+        submissionDate: new Date().toISOString(),
+        sections: sectionRows,
+      }),
+    });
+
+    if (response.ok) {
+      alert("Submission successful");
+    } else {
+      alert("Failed to submit");
     }
   };
 
   return (
-<Layout title="Employee Health and Safety">    
-  <Paper sx={{ p: 4 }} elevation={4}>
-      <Box component="form" onSubmit={handleSubmit}>
-        {definition.sections.map((section, si) => (
-          <Box key={si} sx={{ mb: 3 }}>
-            <Typography variant="h6" gutterBottom>
+    <Layout title={definition.title}>
+      <Paper sx={{ p: 4 }} elevation={4}>
+        <Typography variant="h4" gutterBottom>
+          {definition.title}
+        </Typography>
+        {definition.description && (
+          <Typography component="p" sx={{ mb: 3 }}>
+            {definition.description}
+          </Typography>
+        )}
+        {definition.sections.map((section) => (
+          <Box key={section.title} mb={4}>
+            <Typography variant="h6" fontWeight="bold" gutterBottom>
               {section.title}
             </Typography>
-            <Stack spacing={2}>
-              {section.fields.map((field, fi) => (
-                <Box key={fi}>{renderField(field, `${si}-${fi}`)}</Box>
-              ))}
-            </Stack>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Field</TableCell>
+                  <TableCell>Value</TableCell>
+                  <TableCell />
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {sectionRows[section.title]?.map((row, idx) => {
+                  const field = section.fields.find((f) => f.label === row.fieldKey);
+                  return (
+                    <>
+                      <TableRow key={`${section.title}-${idx}`}>
+                        <TableCell sx={{ width: "30%" }}>
+                          <Select
+                            size="small"
+                            fullWidth
+                            value={row.fieldKey}
+                            onChange={(e) =>
+                              handleSelectField(section.title, idx, e.target.value as string)
+                            }
+                          >
+                            <MenuItem value="">Select field</MenuItem>
+                            {section.fields.map((f) => (
+                              <MenuItem key={f.label} value={f.label}>
+                                {f.label}
+                              </MenuItem>
+                            ))}
+                          </Select>
+                        </TableCell>
+                        <TableCell>
+                          {field && renderFieldControl(field, row, (val) => updateRow(section.title, idx, val))}
+                        </TableCell>
+                        <TableCell>
+                          <IconButton onClick={() => removeRow(section.title, idx)}>
+                            <DeleteIcon />
+                          </IconButton>
+                        </TableCell>
+                      </TableRow>
+                      {field && (field.type === "checkbox" || field.type === "dropdown") && (
+                        <TableRow key={`${section.title}-${idx}-notes`}>
+                          <TableCell colSpan={3}>
+                            <TextField
+                              fullWidth
+                              label="Notes"
+                              value={row.notes || ""}
+                              onChange={(e) => updateRow(section.title, idx, { notes: e.target.value })}
+                            />
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </>
+                  );
+                })}
+              </TableBody>
+            </Table>
           </Box>
         ))}
-        <Button variant="contained" type="submit">
-          Submit
+        <Button onClick={handleSubmit} variant="contained" color="primary">
+          Submit Form
         </Button>
-      </Box>
-    </Paper>
+      </Paper>
     </Layout>
   );
 };


### PR DESCRIPTION
## Summary
- integrate table-driven logic into `FormRenderer`
- simplify Internal Audit Checklist page to use updated renderer

## Testing
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68753c9716988328a78587f0c8734207