### PR TITLE
Use centralized EHS submission helper

### DIFF
--- a/components/FormRenderer.tsx
+++ b/components/FormRenderer.tsx
@@ -18,6 +18,7 @@ import {
   Typography,
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
+import { submitEHSForm } from "@/lib/api";
 
 export type FormField = {
   label: string;
@@ -166,20 +167,16 @@ const FormRenderer = ({ formJson }: { formJson: FormJson }) => {
   };
 
   const handleSubmit = async () => {
-    const response = await fetch("/api/forms/submit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
+    try {
+      await submitEHSForm({
         formTitle: formJson.title,
         submissionDate: new Date().toISOString(),
         sections: sectionRows,
-      }),
-    });
-
-    if (response.ok) {
-      alert("Submission successful");
-    } else {
-      alert("Failed to submit");
+      });
+      alert("Form submitted successfully.");
+    } catch (err) {
+      console.error(err);
+      alert("Failed to submit form.");
     }
   };
 

--- a/components/Forms/FormRenderer.tsx
+++ b/components/Forms/FormRenderer.tsx
@@ -22,6 +22,7 @@ import {
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import Layout from "@/layout/Layout";
+import { submitEHSForm } from "@/lib/api";
 
 export type FormField = {
   label: string;
@@ -170,20 +171,16 @@ const FormRenderer = ({ definition }: { definition: FormDefinition }) => {
   };
 
   const handleSubmit = async () => {
-    const response = await fetch("/api/forms/submit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
+    try {
+      await submitEHSForm({
         formTitle: definition.title,
         submissionDate: new Date().toISOString(),
         sections: sectionRows,
-      }),
-    });
-
-    if (response.ok) {
-      alert("Submission successful");
-    } else {
-      alert("Failed to submit");
+      });
+      alert("Form submitted successfully.");
+    } catch (err) {
+      console.error(err);
+      alert("Failed to submit form.");
     }
   };
 


### PR DESCRIPTION
## Summary
- call `submitEHSForm` for all EHS forms
- send standardized payloads when submitting

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68754abee8788328bddcc9d56853718a