### PR TITLE
Add 30-Day Incident Follow Up form

### DIFF
--- a/app/ehs/page.tsx
+++ b/app/ehs/page.tsx
@@ -11,6 +11,7 @@ import InternalAuditReport from "@/lib/EHS/Internal_Audit_Report.json";
 import ModifiedDutyLog from "@/lib/EHS/Modified_Duty_Log.json";
 import ReturnToWorkAgreement from "@/lib/EHS/Return_to_Work_Agreement.json";
 import SafetyObjectiveWorksheet from "@/lib/EHS/Safety_Objective_Worksheet.json";
+import ThirtyDayIncidentFollowUp from "@/lib/EHS/30dayIncidientFollowUp.json";
 
 const forms = [
   { def: CorrectiveActionRegister, slug: "corrective-action-register" },
@@ -21,6 +22,7 @@ const forms = [
   { def: SafetyObjectiveWorksheet, slug: "safety-objective-worksheet" },
   { def: DailySafetyReview, slug: "daily-safety-review" },
   { def: EquipmentSafetyCheck, slug: "equipment-safety-check" },
+  { def: ThirtyDayIncidentFollowUp, slug: "30day-incident-follow-up" },
 ];
 
 export default function EHSPage() {

--- a/app/forms/30day-incident-follow-up/page.tsx
+++ b/app/forms/30day-incident-follow-up/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+import Layout from "@/layout/Layout";
+import formDefinition from "@/lib/EHS/30dayIncidientFollowUp.json";
+import ThirtyDayIncidentFollowUpForm from "@/components/Forms/ThirtyDayIncidentFollowUpForm";
+import { Typography, Paper } from "@mui/material";
+
+export default function Page() {
+  return (
+    <Layout title={formDefinition.title}>
+      <Paper sx={{ p: 4, mb: 3 }} elevation={4}>
+        <Typography variant="h4" gutterBottom>
+          {formDefinition.title}
+        </Typography>
+        <ThirtyDayIncidentFollowUpForm />
+      </Paper>
+    </Layout>
+  );
+}

--- a/components/Forms/ThirtyDayIncidentFollowUpForm.tsx
+++ b/components/Forms/ThirtyDayIncidentFollowUpForm.tsx
@@ -1,0 +1,9 @@
+"use client";
+import formDefinition from "@/lib/EHS/30dayIncidientFollowUp.json";
+import FormRenderer from "@/components/Forms/FormRenderer";
+
+const ThirtyDayIncidentFollowUpForm = () => (
+  <FormRenderer definition={formDefinition} />
+);
+
+export default ThirtyDayIncidentFollowUpForm;

--- a/lib/EHS/30dayIncidientFollowUp.json
+++ b/lib/EHS/30dayIncidientFollowUp.json
@@ -1,4 +1,6 @@
 {
+  "title": "30-Day Incident Follow Up",
+  "description": "Form to document 30-day follow up details for a dangerous goods incident.",
   "30DayIncidentFollowUpReport": {
     "1_ReportAuthor": {
       "Name": "",


### PR DESCRIPTION
## Summary
- add JSON metadata to 30dayIncidientFollowUp definition
- add form component and page for the 30-day incident follow up
- link new form from the EHS section

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687677006b9c83289e35dbe8acc42a3b