### PR TITLE
Add EHS sub-pages for incident, return to work and checklists

### DIFF
--- a/app/ehs/incident-reporting/page.tsx
+++ b/app/ehs/incident-reporting/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+import Layout from "@/layout/Layout";
+import { List, ListItem, ListItemText, Paper } from "@mui/material";
+import Link from "next/link";
+import CorrectiveActionRegister from "@/lib/EHS/Corrective_Action_Register.json";
+import InternalAuditReport from "@/lib/EHS/Internal_Audit_Report.json";
+import InternalAuditChecklist from "@/lib/EHS/Internal_Audit_Checklist.json";
+import ThirtyDayIncidentFollowUp from "@/lib/EHS/30dayIncidientFollowUp.json";
+
+const forms = [
+  { def: CorrectiveActionRegister, slug: "corrective-action-register" },
+  { def: InternalAuditReport, slug: "internal-audit-report" },
+  { def: InternalAuditChecklist, slug: "internal-audit-checklist" },
+  { def: ThirtyDayIncidentFollowUp, slug: "30day-incident-follow-up" },
+];
+
+export default function IncidentReportingPage() {
+  return (
+    <Layout title="Incident Reporting">
+      <Paper sx={{ p: 4 }} elevation={4}>
+        <List>
+          {forms.map((f) => (
+            <ListItem key={f.slug} component={Link} href={`/forms/${f.slug}`}>
+              <ListItemText primary={f.def.title} />
+            </ListItem>
+          ))}
+        </List>
+      </Paper>
+    </Layout>
+  );
+}

--- a/app/ehs/page.tsx
+++ b/app/ehs/page.tsx
@@ -1,28 +1,23 @@
 "use client";
 import Layout from "@/layout/Layout";
-import { List, ListItem, ListItemText, Typography, Paper } from "@mui/material";
+import { List, ListItem, ListItemText, Paper } from "@mui/material";
 import Link from "next/link";
 import EHSIntro from "@/components/EHSIntro";
 import DailySafetyReview from "@/lib/EHS/Structured_Daily_Safety_Checklist.json";
 import EquipmentSafetyCheck from "@/lib/EHS/Equipment_Inspection_Checklist.json";
-import CorrectiveActionRegister from "@/lib/EHS/Corrective_Action_Register.json";
-import InternalAuditChecklist from "@/lib/EHS/Internal_Audit_Checklist.json";
-import InternalAuditReport from "@/lib/EHS/Internal_Audit_Report.json";
 import ModifiedDutyLog from "@/lib/EHS/Modified_Duty_Log.json";
 import ReturnToWorkAgreement from "@/lib/EHS/Return_to_Work_Agreement.json";
 import SafetyObjectiveWorksheet from "@/lib/EHS/Safety_Objective_Worksheet.json";
-import ThirtyDayIncidentFollowUp from "@/lib/EHS/30dayIncidientFollowUp.json";
 
-const forms = [
-  { def: CorrectiveActionRegister, slug: "corrective-action-register" },
-  { def: InternalAuditChecklist, slug: "internal-audit-checklist" },
-  { def: InternalAuditReport, slug: "internal-audit-report" },
-  { def: ModifiedDutyLog, slug: "modified-duty-log" },
-  { def: ReturnToWorkAgreement, slug: "return-to-work-agreement" },
-  { def: SafetyObjectiveWorksheet, slug: "safety-objective-worksheet" },
-  { def: DailySafetyReview, slug: "daily-safety-review" },
-  { def: EquipmentSafetyCheck, slug: "equipment-safety-check" },
-  { def: ThirtyDayIncidentFollowUp, slug: "30day-incident-follow-up" },
+const links = [
+  { title: "Incident Reporting", href: "/ehs/incident-reporting" },
+  { title: "Return to Work", href: "/ehs/return-to-work" },
+  { title: "Safety Checklists", href: "/ehs/safety-checklists" },
+  { title: ModifiedDutyLog.title, href: "/forms/modified-duty-log" },
+  { title: ReturnToWorkAgreement.title, href: "/forms/return-to-work-agreement" },
+  { title: SafetyObjectiveWorksheet.title, href: "/forms/safety-objective-worksheet" },
+  { title: DailySafetyReview.title, href: "/forms/daily-safety-review" },
+  { title: EquipmentSafetyCheck.title, href: "/forms/equipment-safety-check" },
 ];
 
 export default function EHSPage() {
@@ -39,9 +34,9 @@ export default function EHSPage() {
           Below are the available EHS forms. Select one to begin.
         </Typography> */}
         <List>
-          {forms.map((f) => (
-            <ListItem key={f.slug} component={Link} href={`/forms/${f.slug}`}>
-              <ListItemText primary={f.def.title} />
+          {links.map((l) => (
+            <ListItem key={l.href} component={Link} href={l.href}>
+              <ListItemText primary={l.title} />
             </ListItem>
           ))}
         </List>

--- a/app/ehs/return-to-work/page.tsx
+++ b/app/ehs/return-to-work/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+import Layout from "@/layout/Layout";
+import { List, ListItem, ListItemText, Paper } from "@mui/material";
+import Link from "next/link";
+import ModifiedDutyLog from "@/lib/EHS/Modified_Duty_Log.json";
+import ReturnToWorkAgreement from "@/lib/EHS/Return_to_Work_Agreement.json";
+
+const forms = [
+  { def: ModifiedDutyLog, slug: "modified-duty-log" },
+  { def: ReturnToWorkAgreement, slug: "return-to-work-agreement" },
+];
+
+export default function ReturnToWorkPage() {
+  return (
+    <Layout title="Return to Work">
+      <Paper sx={{ p: 4 }} elevation={4}>
+        <List>
+          {forms.map((f) => (
+            <ListItem key={f.slug} component={Link} href={`/forms/${f.slug}`}>
+              <ListItemText primary={f.def.title} />
+            </ListItem>
+          ))}
+        </List>
+      </Paper>
+    </Layout>
+  );
+}

--- a/app/ehs/safety-checklists/page.tsx
+++ b/app/ehs/safety-checklists/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+import Layout from "@/layout/Layout";
+import { List, ListItem, ListItemText, Paper } from "@mui/material";
+import Link from "next/link";
+import DailySafetyReview from "@/lib/EHS/Structured_Daily_Safety_Checklist.json";
+import EquipmentSafetyCheck from "@/lib/EHS/Equipment_Inspection_Checklist.json";
+
+const forms = [
+  { def: DailySafetyReview, slug: "daily-safety-review" },
+  { def: EquipmentSafetyCheck, slug: "equipment-safety-check" },
+];
+
+export default function SafetyChecklistsPage() {
+  return (
+    <Layout title="Safety Checklists">
+      <Paper sx={{ p: 4 }} elevation={4}>
+        <List>
+          {forms.map((f) => (
+            <ListItem key={f.slug} component={Link} href={`/forms/${f.slug}`}>
+              <ListItemText primary={f.def.title} />
+            </ListItem>
+          ))}
+        </List>
+      </Paper>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add Incident Reporting sub-page listing related forms
- add Return to Work sub-page listing its forms
- add Safety Checklists sub-page under EHS
- update main EHS page navigation to include new pages and remove duplicate form links

## Testing
- `npm run lint`
- `npx tsc --noEmit` *(fails: Property 'sections' is missing in 30DayIncidentFollowUpForm.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_687680202c248328b8dae28e06be485a