### PR TITLE
Add breadcrumb navigation

### DIFF
--- a/components/BreadcrumbsNav.tsx
+++ b/components/BreadcrumbsNav.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Breadcrumbs, Link as MuiLink, Typography } from "@mui/material";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export default function BreadcrumbNav() {
+  const pathname = usePathname();
+  const pathnames = pathname.split("/").filter((x) => x);
+
+  const makeLabel = (segment: string) =>
+    segment
+      .replace(/-/g, " ")
+      .replace(/\b\w/g, (l) => l.toUpperCase());
+
+  let accumulated = "";
+
+  return (
+    <Breadcrumbs sx={{ color: "white", fontWeight: 800, my: 2 }} aria-label="breadcrumb">
+      <MuiLink component={Link} href="/" underline="hover" color="inherit" sx={{ fontWeight: 800 }}>
+        Home
+      </MuiLink>
+      {pathnames.map((segment, index) => {
+        accumulated += `/${segment}`;
+        const label = makeLabel(segment);
+        const isLast = index === pathnames.length - 1;
+
+        return isLast ? (
+          <Typography key={accumulated} color="text.primary" sx={{ fontWeight: 800 }}>
+            {label}
+          </Typography>
+        ) : (
+          <MuiLink key={accumulated} component={Link} href={accumulated} underline="hover" color="inherit" sx={{ fontWeight: 800 }}>
+            {label}
+          </MuiLink>
+        );
+      })}
+    </Breadcrumbs>
+  );
+}

--- a/layout/Layout.tsx
+++ b/layout/Layout.tsx
@@ -1,6 +1,7 @@
 import { Box, Container } from "@mui/material";
 import Head from "next/head";
 import Nav from "@/components/Nav";
+import BreadcrumbNav from "@/components/BreadcrumbsNav";
 import { ReactNode } from "react";
 
 type LayoutProps = {
@@ -70,6 +71,7 @@ const Layout = ({ title = "PM Tool - Spark-E", children }: LayoutProps) => {
         }}
       >
         <Nav />
+        <BreadcrumbNav />
         <Box sx={{ flexGrow: 1, width: "100%", py: 4 }}>{children}</Box>
       </Container>
     </>


### PR DESCRIPTION
## Summary
- build a BreadcrumbNav component to display navigation path
- include BreadcrumbNav in Layout

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6877164e521c8328bff4c10bfc58cc8f