### PR TITLE
Update audit report signature date

### DIFF
--- a/components/BreadcrumbsNav.tsx
+++ b/components/BreadcrumbsNav.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 export default function BreadcrumbNav() {
-  const pathname = usePathname();
+  const pathname = usePathname() ?? "";
   const pathnames = pathname.split("/").filter((x) => x);
 
   const makeLabel = (segment: string) =>

--- a/lib/EHS/Internal_Audit_Report.json
+++ b/lib/EHS/Internal_Audit_Report.json
@@ -45,7 +45,7 @@
         },
         {
           "label": "Date",
-          "type": "date"
+          "type": "staticDate"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- make the auditor signature date static for the Internal Audit Report
- fix pathname null case in BreadcrumbNav

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68771b058058832887c6dc6ac1afd866