### PR TITLE
Update audit report signature date

### DIFF
--- a/components/BreadcrumbsNav.tsx
+++ b/components/BreadcrumbsNav.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 export default function BreadcrumbNav() {
-  const pathname = usePathname();
+  const pathname = usePathname() ?? "";
   const pathnames = pathname.split("/").filter((x) => x);
 
   const makeLabel = (segment: string) =>
@@ -24,15 +24,27 @@ export default function BreadcrumbNav() {
         accumulated += `/${segment}`;
         const label = makeLabel(segment);
         const isLast = index === pathnames.length - 1;
+        const isLink = !isLast && segment !== "forms";
 
-        return isLast ? (
-          <Typography key={accumulated} color="text.primary" sx={{ fontWeight: 800 }}>
-            {label}
-          </Typography>
-        ) : (
-          <MuiLink key={accumulated} component={Link} href={accumulated} underline="hover" color="inherit" sx={{ fontWeight: 800 }}>
+        return isLink ? (
+          <MuiLink
+            key={accumulated}
+            component={Link}
+            href={accumulated}
+            underline="hover"
+            color="inherit"
+            sx={{ fontWeight: 800 }}
+          >
             {label}
           </MuiLink>
+        ) : (
+          <Typography
+            key={accumulated}
+            color="text.primary"
+            sx={{ fontWeight: 800 }}
+          >
+            {label}
+          </Typography>
         );
       })}
     </Breadcrumbs>

--- a/components/FormRenderer.tsx
+++ b/components/FormRenderer.tsx
@@ -19,6 +19,7 @@ import {
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { submitEHSForm } from "@/lib/api";
+import SignaturePad from "./SignaturePad";
 
 export type FormField = {
   label: string;
@@ -106,6 +107,24 @@ const renderFieldControl = (
           fullWidth
         />
       );
+    case "signature":
+      return (
+        <Box>
+          <TextField
+            type="date"
+            value={row.value?.date || new Date().toISOString().split("T")[0]}
+            disabled
+            fullWidth
+            sx={{ mb: 1 }}
+          />
+          <SignaturePad
+            value={row.value?.signature || ""}
+            onChange={(data) =>
+              update({ value: { ...(row.value || {}), signature: data } })
+            }
+          />
+        </Box>
+      );
     case "text":
     default:
       return (
@@ -148,7 +167,16 @@ const FormRenderer = ({ formJson }: { formJson: FormJson }) => {
   ) => {
     setSectionRows((prev) => {
       const rows = prev[section] ? [...prev[section]] : [];
-      rows[idx] = { fieldKey };
+      const field = formJson.sections
+        .find((s) => s.title === section)?.fields.find((f) => f.label === fieldKey);
+      const rowData: RowData = { fieldKey };
+      if (field?.type === "signature") {
+        rowData.value = {
+          date: new Date().toISOString().split("T")[0],
+          signature: "",
+        };
+      }
+      rows[idx] = rowData;
       // append new row if last and not empty
       if (idx === rows.length - 1 && fieldKey) {
         rows.push({ fieldKey: "" });

--- a/components/SignaturePad.tsx
+++ b/components/SignaturePad.tsx
@@ -1,0 +1,107 @@
+import { useRef, useEffect } from "react";
+
+const SignaturePad = ({
+  value,
+  onChange,
+}: {
+  value?: string;
+  onChange: (dataUrl: string) => void;
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const drawing = useRef(false);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.lineWidth = 2;
+    ctx.lineCap = "round";
+
+    const start = (e: MouseEvent | TouchEvent) => {
+      drawing.current = true;
+      const { offsetX, offsetY } = getPoint(e, canvas);
+      ctx.beginPath();
+      ctx.moveTo(offsetX, offsetY);
+    };
+
+    const draw = (e: MouseEvent | TouchEvent) => {
+      if (!drawing.current) return;
+      const { offsetX, offsetY } = getPoint(e, canvas);
+      ctx.lineTo(offsetX, offsetY);
+      ctx.stroke();
+    };
+
+    const end = () => {
+      if (!drawing.current) return;
+      drawing.current = false;
+      onChange(canvas.toDataURL());
+    };
+
+    const mouseup = () => end();
+    const touchend = () => end();
+
+    canvas.addEventListener("mousedown", start);
+    canvas.addEventListener("mousemove", draw);
+    window.addEventListener("mouseup", mouseup);
+    canvas.addEventListener("touchstart", start);
+    canvas.addEventListener("touchmove", draw);
+    window.addEventListener("touchend", touchend);
+
+    return () => {
+      canvas.removeEventListener("mousedown", start);
+      canvas.removeEventListener("mousemove", draw);
+      window.removeEventListener("mouseup", mouseup);
+      canvas.removeEventListener("touchstart", start);
+      canvas.removeEventListener("touchmove", draw);
+      window.removeEventListener("touchend", touchend);
+    };
+  }, [onChange]);
+
+  const clear = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    onChange("");
+  };
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas && value) {
+      const img = new Image();
+      img.src = value;
+      img.onload = () => {
+        const ctx = canvas.getContext("2d");
+        if (ctx) ctx.drawImage(img, 0, 0);
+      };
+    }
+  }, [value]);
+
+  return (
+    <div>
+      <canvas
+        ref={canvasRef}
+        width={300}
+        height={150}
+        style={{ border: "1px solid #000", display: "block" }}
+      />
+      <button type="button" onClick={clear} style={{ marginTop: 4 }}>
+        Clear
+      </button>
+    </div>
+  );
+};
+
+function getPoint(e: MouseEvent | TouchEvent, canvas: HTMLCanvasElement) {
+  if (e instanceof MouseEvent) {
+    const rect = canvas.getBoundingClientRect();
+    return { offsetX: e.clientX - rect.left, offsetY: e.clientY - rect.top };
+  }
+  const t = e.touches[0];
+  const rect = canvas.getBoundingClientRect();
+  return { offsetX: t.clientX - rect.left, offsetY: t.clientY - rect.top };
+}
+
+export default SignaturePad;

--- a/lib/EHS/Internal_Audit_Report.json
+++ b/lib/EHS/Internal_Audit_Report.json
@@ -42,10 +42,6 @@
         {
           "label": "Auditor Signature",
           "type": "signature"
-        },
-        {
-          "label": "Date",
-          "type": "date"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- make the signature field include a fixed date
- update Internal Audit Report to only use the signature field
- avoid broken "Forms" link in breadcrumbs

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68771b058058832887c6dc6ac1afd866