### PR TITLE
Add signature/date before form submission

### DIFF
--- a/app/forms/internal-audit-report/page.tsx
+++ b/app/forms/internal-audit-report/page.tsx
@@ -2,54 +2,17 @@
 import Layout from "@/layout/Layout";
 import formDefinition from "@/lib/EHS/Internal_Audit_Report.json";
 import InternalAuditReportForm from "@/components/Forms/InternalAuditReportForm";
-import { Typography, Paper, Box, TextField, Button } from "@mui/material";
-import SignaturePad from "@/components/SignaturePad";
-import { useState, useEffect, Fragment, ReactNode } from "react";
-import { submitEHSForm } from "@/lib/api";
+import { Typography, Paper } from "@mui/material";
 
 export default function Page() {
-  const [clientSig, setClientSig] = useState("");
-
-  const handleSubmit = async () => {
-    try {
-      await submitEHSForm({
-        formTitle: formJson.title,
-        submissionDate: new Date().toISOString(),
-        sections: sectionRows,
-      });
-      alert("Form submitted successfully.");
-    } catch (err) {
-      console.error(err);
-      alert("Failed to submit form.");
-    }
-  };
   return (
     <Layout title={formDefinition.title}>
       <Paper sx={{ p: 4, mb: 3 }} elevation={4}>
         <Typography variant="h4" gutterBottom>
           {formDefinition.title}
         </Typography>
-        <Typography component={"p"}>{formDefinition.description}</Typography>
-        <Box sx={{ mb: 2 }}>
-          <InternalAuditReportForm />
-
-          <SignaturePad
-            onChange={(sig) => {
-              setClientSig(sig);
-            }}
-          />
-          <TextField
-            type="date"
-            value={new Date().toISOString().split("T")[0]}
-            disabled
-            fullWidth
-            sx={{ mb: 1 }}
-          />
-
-          <Button onClick={handleSubmit} variant="contained" color="primary">
-            Submit Form here
-          </Button>
-        </Box>
+        <Typography component="p">{formDefinition.description}</Typography>
+        <InternalAuditReportForm />
       </Paper>
     </Layout>
   );

--- a/components/EstimateForm.tsx
+++ b/components/EstimateForm.tsx
@@ -25,6 +25,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
 import { getServices, ServiceItem } from "@/lib/msLists";
 import { sendEstimateEmail, ensureCustomerFolder } from "@/lib/api";
+import SignaturePad from "@/components/SignaturePad";
 
 const provinces = [
   { code: "AB", name: "Alberta" },
@@ -98,6 +99,8 @@ const EstimateForm = () => {
   const [hydroFee, setHydroFee] = useState(0);
   const [discountType, setDiscountType] = useState("None");
   const [discountValue, setDiscountValue] = useState(0);
+  const [signature, setSignature] = useState("");
+  const currentDate = new Date().toISOString().split("T")[0];
 
   useEffect(() => {
     getServices().then(setServices);
@@ -558,6 +561,8 @@ const EstimateForm = () => {
               <Typography variant="h6" fontWeight="bold">
                 Grand Total: {grandTotal.toFixed(2)}
               </Typography>
+              <SignaturePad onChange={setSignature} />
+              <TextField type="date" value={currentDate} disabled fullWidth sx={{ mb: 1 }} />
               <Button type="submit" variant="contained">
                 Submit Estimate
               </Button>

--- a/components/Forms/EquipmentSafetyCheck.tsx
+++ b/components/Forms/EquipmentSafetyCheck.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import SignaturePad from "@/components/SignaturePad";
 import {
   Box,
   Paper,
@@ -22,6 +23,8 @@ const safetyChecks = [
 const EquipmentSafetyCheck = () => {
   const [selectedEquipment, setSelectedEquipment] = useState("");
   const [checks, setChecks] = useState<boolean[]>(safetyChecks.map(() => false));
+  const [signature, setSignature] = useState("");
+  const currentDate = new Date().toISOString().split("T")[0];
 
   const toggleCheck = (i: number) => {
     const updated = [...checks];
@@ -67,6 +70,9 @@ const EquipmentSafetyCheck = () => {
               label={item}
             />
           ))}
+
+          <SignaturePad onChange={setSignature} />
+          <TextField type="date" value={currentDate} disabled fullWidth sx={{ mb: 1 }} />
 
           <Button variant="contained" type="submit">
             Submit Equipment Check

--- a/components/Forms/FormRenderer.tsx
+++ b/components/Forms/FormRenderer.tsx
@@ -23,6 +23,7 @@ import {
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import Layout from "@/layout/Layout";
+import SignaturePad from "@/components/SignaturePad";
 
 export type FormField = {
   label: string;
@@ -137,6 +138,8 @@ const renderFieldControl = (
 
 const FormRenderer = ({ definition }: { definition: FormDefinition }) => {
   const [sectionRows, setSectionRows] = useState<Record<string, RowData[]>>({});
+  const [signature, setSignature] = useState("");
+  const currentDate = new Date().toISOString().split("T")[0];
 
   useEffect(() => {
     const init: Record<string, RowData[]> = {};
@@ -182,6 +185,8 @@ const FormRenderer = ({ definition }: { definition: FormDefinition }) => {
         formTitle: definition.title,
         submissionDate: new Date().toISOString(),
         sections: sectionRows,
+        signature,
+        date: currentDate,
       }),
     });
 
@@ -264,6 +269,12 @@ const FormRenderer = ({ definition }: { definition: FormDefinition }) => {
           </Table>
         </Box>
       ))}
+      <Typography variant="h6" fontWeight="bold" gutterBottom>
+        Signature
+      </Typography>
+      <SignaturePad onChange={setSignature} />
+      <TextField type="date" value={currentDate} disabled sx={{ mb: 1 }} />
+
       <Button onClick={handleSubmit} variant="contained" color="primary">
         Submit Form
       </Button>

--- a/components/JobSiteJournalForm.tsx
+++ b/components/JobSiteJournalForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { fetchWeather, Weather } from "@/lib/weather";
 import { Box, Button, Paper, Stack, TextField, Typography, Slider } from "@mui/material";
+import SignaturePad from "@/components/SignaturePad";
 import { getTasks, submitJournalEntry } from "@/lib/msLists";
 import {
   saveJournalDraft,
@@ -23,6 +24,8 @@ const JobSiteJournalForm = () => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [weather, setWeather] = useState<Weather | null>(null);
   const [weatherUpdatedAt, setWeatherUpdatedAt] = useState<string | null>(null);
+  const [signature, setSignature] = useState("");
+  const currentDate = new Date().toISOString().split("T")[0];
 
   const cacheKey = "cachedWeather";
 
@@ -172,6 +175,8 @@ const JobSiteJournalForm = () => {
               ))}
             </Stack>
           </Box>
+          <SignaturePad onChange={setSignature} />
+          <TextField type="date" value={currentDate} disabled fullWidth sx={{ mb: 1 }} />
           <Button type="submit" variant="contained">
             Submit
           </Button>

--- a/components/TaskEntryForm.tsx
+++ b/components/TaskEntryForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Box, Button, Paper, Stack, TextField, Typography } from "@mui/material";
+import SignaturePad from "@/components/SignaturePad";
 
 type Subtask = { name: string };
 type Material = { name: string; dateNeeded: string; leadTimeDays: number };
@@ -11,6 +12,8 @@ const TaskEntryForm = () => {
   const [subtasks, setSubtasks] = useState<Subtask[]>([]);
   const [materials, setMaterials] = useState<Material[]>([]);
   const [equipment, setEquipment] = useState<Equipment[]>([]);
+  const [signature, setSignature] = useState("");
+  const currentDate = new Date().toISOString().split("T")[0];
 
   const addSubtask = () => setSubtasks([...subtasks, { name: "" }]);
   const updateSubtask = (index: number, value: string) => {
@@ -159,6 +162,8 @@ const TaskEntryForm = () => {
               + Add Equipment
             </Button>
           </Box>
+          <SignaturePad onChange={setSignature} />
+          <TextField type="date" value={currentDate} disabled fullWidth sx={{ mb: 1 }} />
           <Button type="submit" variant="contained">
             Save Task
           </Button>

--- a/components/ToolRequestForm.tsx
+++ b/components/ToolRequestForm.tsx
@@ -8,12 +8,15 @@ import {
   Typography,
 } from "@mui/material";
 import { useState } from "react";
+import SignaturePad from "@/components/SignaturePad";
 
 const ToolRequestForm = () => {
   const [toolName, setToolName] = useState("");
   const [quantity, setQuantity] = useState(1);
   const [priority, setPriority] = useState("Normal");
   const [notes, setNotes] = useState("");
+  const [signature, setSignature] = useState("");
+  const currentDate = new Date().toISOString().split("T")[0];
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -77,6 +80,8 @@ const ToolRequestForm = () => {
             multiline
             minRows={3}
           />
+          <SignaturePad onChange={setSignature} />
+          <TextField type="date" value={currentDate} disabled fullWidth sx={{ mb: 1 }} />
           <Box textAlign="right">
             <Button type="submit" variant="contained" size="large">
               Submit Request


### PR DESCRIPTION
## Summary
- simplify internal audit report page
- include SignaturePad and date in general form renderer
- add signature/date fields to equipment, tool request, job journal, task entry and estimate forms

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6877ab1db4c883289eac92cac59473e7